### PR TITLE
PE-105: Setup state management tools with `useReducer` / `useContext`

### DIFF
--- a/src/components/UnitBox.example.tsx
+++ b/src/components/UnitBox.example.tsx
@@ -1,0 +1,40 @@
+import { useStateValue } from '../state/state';
+import React, { CSSProperties } from 'react';
+import type { UnitBoxes } from '../types';
+
+interface UnitBoxProps {
+	field: keyof UnitBoxes;
+}
+
+/**
+ * This is a temporary component that was made for testing the state
+ * management setup. The pattern used here will be integrated into the
+ * statically framed elements during the upcoming AR -> Data ticket
+ */
+export function UnitBox({ field }: UnitBoxProps): JSX.Element {
+	const [{ unitBoxes }, dispatch] = useStateValue();
+
+	const style: CSSProperties = { textAlign: 'center', padding: '0.6rem', fontSize: '1rem' };
+	const bigFontStyle: CSSProperties = { ...style, fontSize: '2rem' };
+
+	return (
+		<div style={style}>
+			<div style={bigFontStyle}>value: {unitBoxes[field].value}</div>
+			<div style={style}>currUnit: {unitBoxes[field].currUnit}</div>
+			<button
+				style={style}
+				onClick={() =>
+					dispatch({
+						type: 'setUnitBoxes',
+						payload: {
+							...unitBoxes,
+							[field]: { ...unitBoxes[field], value: Math.floor(Math.random() * 1000) }
+						}
+					})
+				}
+			>
+				randomize {field} unit box
+			</button>
+		</div>
+	);
+}

--- a/src/components/UnitBox.example.tsx
+++ b/src/components/UnitBox.example.tsx
@@ -9,7 +9,8 @@ interface UnitBoxProps {
 /**
  * This is a temporary component that was made for testing the state
  * management setup. The pattern used here will be integrated into the
- * statically framed elements during the upcoming AR -> Data ticket
+ * statically framed elements during the upcoming AR -> Data ticket:
+ * PE-67: https://ardrive.atlassian.net/browse/PE-67?atlOrigin=eyJpIjoiMzRhY2VkNjYwMzBlNDVmNDk0MWQ5NGI0NmMwMjg3ODEiLCJwIjoiaiJ9
  */
 export function UnitBox({ field }: UnitBoxProps): JSX.Element {
 	const [{ unitBoxes }, dispatch] = useStateValue();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,10 +7,16 @@ import App from './components/App';
 import StateProvider from './state/state';
 import { reducer } from './state/reducer';
 
+import { UnitBox } from './components/UnitBox.example';
+
 ReactDOM.render(
 	<React.StrictMode>
 		<StateProvider reducer={reducer}>
 			<App />
+			{/** These UnitBoxes are only for testing state management PR */}
+			<UnitBox field="bytes" />
+			<UnitBox field="fiat" />
+			<UnitBox field="ar" />
 		</StateProvider>
 	</React.StrictMode>,
 	document.getElementById('root')

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,10 +4,14 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import App from './components/App';
+import StateProvider from './state/state';
+import { reducer } from './state/reducer';
 
 ReactDOM.render(
 	<React.StrictMode>
-		<App />
+		<StateProvider reducer={reducer}>
+			<App />
+		</StateProvider>
 	</React.StrictMode>,
 	document.getElementById('root')
 );

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -1,0 +1,47 @@
+import type { ArDriveCommunityTip, ArToData, FiatToAr, UnitBoxes } from 'src/types';
+import type { State } from './state';
+
+export type Action =
+	| { type: 'setArToData'; payload: ArToData }
+	| { type: 'setArDriveCommunityTip'; payload: ArDriveCommunityTip }
+	| { type: 'setFiatToAr'; payload: FiatToAr }
+	| { type: 'setUnitBoxes'; payload: UnitBoxes };
+
+export const reducer = (state: State, action: Action): State => {
+	switch (action.type) {
+		case 'setArToData':
+			return {
+				...state,
+				arToData: action.payload
+			};
+
+		case 'setArDriveCommunityTip':
+			return {
+				...state,
+				arDriveCommunityTip: action.payload
+			};
+
+		case 'setFiatToAr':
+			return {
+				...state,
+				fiatToArData: action.payload
+			};
+
+		/**
+		 * @TODO The unit boxes will be calculated together based off of any change
+		 * to their values or current unit fields
+		 *
+		 * We'll add a calculation hook `useCalculate` that will be fired immediately
+		 * upon unit change, and initially debounced when a value is changed
+		 *
+		 */
+		case 'setUnitBoxes':
+			return {
+				...state,
+				unitBoxes: action.payload
+			};
+
+		default:
+			return state;
+	}
+};

--- a/src/state/state.tsx
+++ b/src/state/state.tsx
@@ -1,0 +1,63 @@
+import React, { createContext, Dispatch, useContext, useReducer } from 'react';
+import { ArDriveCommunityTip, ArToData, byteUnitTypes, FiatToAr, fiatUnitTypes, UnitBoxes } from '../types';
+import type { Action } from './reducer';
+
+export type State = {
+	/**
+	 * To be fetched and then calculated by linear regression. If arToData
+	 * remains undefined, the AR / Fiat input field should not be rendered
+	 */
+	arToData?: ArToData;
+
+	/**
+	 * ArDrive Community tip percentage and minimum community tip are to be read
+	 * from the SmartWeave contract on startup, uses known defaults until data arrives
+	 */
+	arDriveCommunityTip: ArDriveCommunityTip;
+
+	/** Fiat to AR conversions to be fetched from CoinGecko */
+	fiatToArData?: FiatToAr;
+
+	/** Current values and units for each field: 'bytes' | 'fiat' | 'ar' */
+	unitBoxes: UnitBoxes;
+};
+
+/** ArDrive Price Calculator's initial state */
+const initialState: State = {
+	arDriveCommunityTip: {
+		/** Default ArDrive Community Tip percentage */
+		tipPercentage: 0.15,
+		/** Default ArDrive Minimum Community Tip in winston */
+		minWinstonTip: 10_000_000
+	},
+
+	/** Unit boxes display only 1 GB by default, other values to be filled in on first calculation */
+	unitBoxes: {
+		bytes: { value: 1, currUnit: 'GB', units: byteUnitTypes },
+		fiat: { value: 0, currUnit: 'USD', units: fiatUnitTypes },
+		ar: { value: 0, currUnit: 'AR' }
+	}
+};
+
+/** Create a context with initial state, and a dispatch function */
+const StateContext = createContext<[State, Dispatch<Action>]>([initialState, () => initialState]);
+
+/**
+ *  Export easy to use context hook
+ *
+ *  @example
+ *  const [{ arDriveCommunityTip }, dispatch] = useStateValue()
+ *  dispatch({ type: 'setArDriveCommunityTip', payload: arDriveCommTipFromContract })
+ */
+export const useStateValue = (): [State, Dispatch<Action>] => useContext(StateContext);
+
+type StateProviderProps = {
+	reducer: React.Reducer<State, Action>;
+	children: React.ReactNode;
+};
+
+/** Create provider to wrap app in */
+export default function StateProvider({ reducer, children }: StateProviderProps): JSX.Element {
+	const [state, dispatch] = useReducer(reducer, initialState);
+	return <StateContext.Provider value={[state, dispatch]}>{children}</StateContext.Provider>;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,54 @@
+export interface ArDriveCommunityTip {
+	tipPercentage: number;
+	minWinstonTip: number;
+}
+
+export interface ArToData {
+	winstonPerByte: number;
+	baseFee: number;
+}
+
+export type FiatToAr = {
+	// [FiatUnits in FiatUnitTypes]: number;
+	[key: string]: number;
+};
+
+interface UnitBox {
+	/** Value displayed on left on unit box */
+	value: number;
+	/** Current unit selected by the user */
+	currUnit: string;
+	/** All available units */
+	units?: readonly string[];
+}
+
+export interface BytesUnitBox extends UnitBox {
+	currUnit: ByteUnitTypes;
+	units: readonly ByteUnitTypes[];
+}
+
+export interface FiatUnitBox extends UnitBox {
+	currUnit: FiatUnitTypes;
+	units: readonly FiatUnitTypes[];
+}
+
+export interface ArUnitBox extends UnitBox {
+	currUnit: 'AR';
+}
+
+export const byteUnitTypes = ['KB', 'MB', 'GB'] as const;
+export type ByteUnitTypes = typeof byteUnitTypes[number];
+
+// prettier-ignore
+export const fiatUnitTypes = ['USD', 'EUR', 'JPY', 'CNY', 'GBP', 'IDR', 'TWD',
+    'KRW', 'RUB', 'AED', 'ARS', 'AUD', 'BDT', 'BHD', 'BMD', 'BRL', 'CAD', 'CHF',
+    'CLP', 'CZK', 'DKK', 'HKD', 'HUF', 'ILS', 'INR', 'KWD', 'LKR', 'MMK', 'MXN',
+    'MYR', 'NGN', 'NOK', 'NZD', 'PHP', 'PKR', 'PLN', 'SAR', 'SEK', 'SGD', 'THB',
+    'TRY', 'UAH', 'VEF', 'VND', 'ZAR', 'XDR', 'XAG','XAU'] as const;
+export type FiatUnitTypes = typeof fiatUnitTypes[number];
+
+export interface UnitBoxes {
+	bytes: BytesUnitBox;
+	fiat: FiatUnitBox;
+	ar: ArUnitBox;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,13 +23,13 @@ interface UnitBox {
 }
 
 export interface BytesUnitBox extends UnitBox {
-	currUnit: ByteUnitTypes;
-	units: readonly ByteUnitTypes[];
+	currUnit: ByteUnitType;
+	units: readonly ByteUnitType[];
 }
 
 export interface FiatUnitBox extends UnitBox {
-	currUnit: FiatUnitTypes;
-	units: readonly FiatUnitTypes[];
+	currUnit: FiatUnitType;
+	units: readonly FiatUnitType[];
 }
 
 export interface ArUnitBox extends UnitBox {
@@ -37,7 +37,7 @@ export interface ArUnitBox extends UnitBox {
 }
 
 export const byteUnitTypes = ['KB', 'MB', 'GB'] as const;
-export type ByteUnitTypes = typeof byteUnitTypes[number];
+export type ByteUnitType = typeof byteUnitTypes[number];
 
 // prettier-ignore
 export const fiatUnitTypes = ['USD', 'EUR', 'JPY', 'CNY', 'GBP', 'IDR', 'TWD',
@@ -45,7 +45,7 @@ export const fiatUnitTypes = ['USD', 'EUR', 'JPY', 'CNY', 'GBP', 'IDR', 'TWD',
     'CLP', 'CZK', 'DKK', 'HKD', 'HUF', 'ILS', 'INR', 'KWD', 'LKR', 'MMK', 'MXN',
     'MYR', 'NGN', 'NOK', 'NZD', 'PHP', 'PKR', 'PLN', 'SAR', 'SEK', 'SGD', 'THB',
     'TRY', 'UAH', 'VEF', 'VND', 'ZAR', 'XDR', 'XAG','XAU'] as const;
-export type FiatUnitTypes = typeof fiatUnitTypes[number];
+export type FiatUnitType = typeof fiatUnitTypes[number];
 
 export interface UnitBoxes {
 	bytes: BytesUnitBox;


### PR DESCRIPTION
This PR adds an easy to use `useStateValue()` hook that will hold the global state for the ArDrive Price Calculator.

There is a `UnitBox` component in this branch that is only for example and for testing this PR. The state management pattern and types used in this component will be applied to the statically framed branch in an upcoming ticket.