### PR TITLE
PE-176: Limit text inputs to numbers only on Firefox and Safari

### DIFF
--- a/src/components/TextBox.tsx
+++ b/src/components/TextBox.tsx
@@ -18,8 +18,10 @@ export default function TextBox({ field }: TextBoxProps): JSX.Element {
 	const [localInputValue, setLocalInputValue] = useState(globalInputValue.toString());
 	const [isDebouncing, setIsDebouncing] = useState(false);
 
-	if (Number(localInputValue) !== globalInputValue && !isDebouncing) {
-		// Calculation has been changed in the global state, set to new local value if NOT debouncing
+	if (Number(localInputValue) !== globalInputValue && !isDebouncing && localInputValue !== '.') {
+		// Calculation has been changed in the global state, set to new local value
+		// only if NOT debouncing and if the localInputValue is not a single decimal
+		// The special case for the single dot allows the user to begin typing a decimal
 		setLocalInputValue(globalInputValue.toString());
 	}
 
@@ -53,14 +55,16 @@ export default function TextBox({ field }: TextBoxProps): JSX.Element {
 	function onTextBoxInputChange(event: React.ChangeEvent<HTMLInputElement>): void {
 		let userInputValue = event.target.value;
 
-		// Only trigger debounce from local value change if the
-		// user defined input is a valid input
+		// Only set local input value if the user defined input is a valid input
 		if (isValidInput(userInputValue)) {
-			setIsDebouncing(true);
+			if (userInputValue !== '.') {
+				// Only trigger debounce if the input is not a solo decimal
+				setIsDebouncing(true);
 
-			if (Number(userInputValue) < 0) {
-				// Enforce positive integers with Math.abs()
-				userInputValue = Math.abs(Number(userInputValue)).toString();
+				if (Number(userInputValue) < 0) {
+					// Enforce any negative integers into positive integers with Math.abs()
+					userInputValue = Math.abs(Number(userInputValue)).toString();
+				}
 			}
 
 			setLocalInputValue(userInputValue);

--- a/src/components/TextBox.tsx
+++ b/src/components/TextBox.tsx
@@ -55,10 +55,13 @@ export default function TextBox({ field }: TextBoxProps): JSX.Element {
 	function onTextBoxInputChange(event: React.ChangeEvent<HTMLInputElement>): void {
 		let userInputValue = event.target.value;
 
-		// Only set local input value if the user defined input is a valid input
 		if (isValidInput(userInputValue)) {
-			if (userInputValue !== '.') {
-				// Only trigger debounce if the input is not a solo decimal
+			// Only set local input value if the user defined input is a valid input
+			if (userInputValue === '.') {
+				// When input is changed to a single decimal, cancel debounce
+				setIsDebouncing(false);
+			} else {
+				// Otherwise, trigger new debounce
 				setIsDebouncing(true);
 
 				if (Number(userInputValue) < 0) {
@@ -66,7 +69,6 @@ export default function TextBox({ field }: TextBoxProps): JSX.Element {
 					userInputValue = Math.abs(Number(userInputValue)).toString();
 				}
 			}
-
 			setLocalInputValue(userInputValue);
 		}
 	}

--- a/src/components/TextBox.tsx
+++ b/src/components/TextBox.tsx
@@ -5,7 +5,7 @@ import type { UnitBoxes } from '../types';
 import { useStateValue } from '../state/state';
 import useDebounce from '../hooks/useDebounce';
 import { useState } from 'react';
-import isValidInput from '../utils/valid_input_reg_exp';
+import isValidInput, { validInputRegExp } from '../utils/valid_input_reg_exp';
 
 interface TextBoxProps {
 	field: keyof UnitBoxes;
@@ -78,7 +78,7 @@ export default function TextBox({ field }: TextBoxProps): JSX.Element {
 			<TextBoxInput
 				style={hideInput}
 				type="text"
-				pattern="^[0-9]*[.]?[0-9]*$"
+				pattern={validInputRegExp.source}
 				name="textbox"
 				value={localInputValue}
 				onChange={onTextBoxInputChange}

--- a/src/components/TextBox.tsx
+++ b/src/components/TextBox.tsx
@@ -5,6 +5,7 @@ import type { UnitBoxes } from '../types';
 import { useStateValue } from '../state/state';
 import useDebounce from '../hooks/useDebounce';
 import { useState } from 'react';
+import isValidInput from '../utils/valid_input_reg_exp';
 
 interface TextBoxProps {
 	field: keyof UnitBoxes;
@@ -52,9 +53,9 @@ export default function TextBox({ field }: TextBoxProps): JSX.Element {
 	function onTextBoxInputChange(event: React.ChangeEvent<HTMLInputElement>): void {
 		let userInputValue = event.target.value;
 
-		// Only trigger debounced from local value change if the
-		// user defined input converts to a number
-		if (!Number.isNaN(userInputValue)) {
+		// Only trigger debounce from local value change if the
+		// user defined input is a valid input
+		if (isValidInput(userInputValue)) {
 			setIsDebouncing(true);
 
 			if (Number(userInputValue) < 0) {
@@ -70,7 +71,8 @@ export default function TextBox({ field }: TextBoxProps): JSX.Element {
 		<TextBoxContainer>
 			<TextBoxInput
 				style={hideInput}
-				type="number"
+				type="text"
+				pattern="^[0-9]*[.]?[0-9]*$"
 				name="textbox"
 				value={localInputValue}
 				onChange={onTextBoxInputChange}

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,11 @@
     display: flex;
 }
 
+svg {
+    width: 100%;
+    height: 100%;
+}
+
 ul {
     list-style: none;
 }

--- a/src/utils/valid_input_reg_exp.test.ts
+++ b/src/utils/valid_input_reg_exp.test.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import isValidInput from './valid_input_reg_exp';
+
+const unexpectedValues = [
+	'pants',
+	't9.02',
+	'0.2.5',
+	'888.88e80',
+	'..90',
+	'99..',
+	'ultimate.number',
+	'0.00842.2',
+	'R2.D2'
+];
+
+const expectedValues = [
+	'0',
+	'',
+	'0.',
+	'0.0',
+	'0.001',
+	'8759.',
+	'123456789.987654321',
+	'008861',
+	'55555.55555',
+	Number.MAX_SAFE_INTEGER.toString()
+];
+
+describe('isValidInput function', () => {
+	it('returns false with unexpected values', () => {
+		for (const value of unexpectedValues) {
+			expect(isValidInput(value)).to.be.false;
+		}
+	});
+
+	it('returns false with expected values', () => {
+		for (const value of expectedValues) {
+			expect(isValidInput(value)).to.be.true;
+		}
+	});
+});

--- a/src/utils/valid_input_reg_exp.test.ts
+++ b/src/utils/valid_input_reg_exp.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import isValidInput from './valid_input_reg_exp';
 
-const unexpectedValues = [
+const invalidValues = [
 	'pants',
 	't9.02',
 	'0.2.5',
@@ -9,11 +9,11 @@ const unexpectedValues = [
 	'..90',
 	'99..',
 	'ultimate.number',
-	'0.00842.2',
+	'0.00842.2654.433',
 	'R2.D2'
 ];
 
-const expectedValues = [
+const validValues = [
 	'0',
 	'',
 	'0.',
@@ -27,14 +27,14 @@ const expectedValues = [
 ];
 
 describe('isValidInput function', () => {
-	it('returns false with unexpected values', () => {
-		for (const value of unexpectedValues) {
+	it('returns false when used with invalid values', () => {
+		for (const value of invalidValues) {
 			expect(isValidInput(value)).to.be.false;
 		}
 	});
 
-	it('returns false with expected values', () => {
-		for (const value of expectedValues) {
+	it('returns true when used with valid values', () => {
+		for (const value of validValues) {
 			expect(isValidInput(value)).to.be.true;
 		}
 	});

--- a/src/utils/valid_input_reg_exp.test.ts
+++ b/src/utils/valid_input_reg_exp.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import isValidInput from './valid_input_reg_exp';
+import isValidNumericUserInputString from './valid_input_reg_exp';
 
 const invalidValues = [
 	'pants',
@@ -26,16 +26,16 @@ const validValues = [
 	Number.MAX_SAFE_INTEGER.toString()
 ];
 
-describe('isValidInput function', () => {
+describe('isValidNumericUserInputString function', () => {
 	it('returns false when used with invalid values', () => {
 		for (const value of invalidValues) {
-			expect(isValidInput(value)).to.be.false;
+			expect(isValidNumericUserInputString(value)).to.be.false;
 		}
 	});
 
 	it('returns true when used with valid values', () => {
 		for (const value of validValues) {
-			expect(isValidInput(value)).to.be.true;
+			expect(isValidNumericUserInputString(value)).to.be.true;
 		}
 	});
 });

--- a/src/utils/valid_input_reg_exp.ts
+++ b/src/utils/valid_input_reg_exp.ts
@@ -1,0 +1,5 @@
+const validInputRegExp = new RegExp('^[0-9]*[.]?[0-9]*$');
+
+export default function isValidInput(input: string): boolean {
+	return validInputRegExp.test(input);
+}

--- a/src/utils/valid_input_reg_exp.ts
+++ b/src/utils/valid_input_reg_exp.ts
@@ -1,5 +1,5 @@
 export const validInputRegExp = new RegExp('^[0-9]*[.]?[0-9]*$');
 
-export default function isValidInput(input: string): boolean {
+export default function isValidNumericUserInputString(input: string): boolean {
 	return validInputRegExp.test(input);
 }

--- a/src/utils/valid_input_reg_exp.ts
+++ b/src/utils/valid_input_reg_exp.ts
@@ -1,4 +1,4 @@
-const validInputRegExp = new RegExp('^[0-9]*[.]?[0-9]*$');
+export const validInputRegExp = new RegExp('^[0-9]*[.]?[0-9]*$');
 
 export default function isValidInput(input: string): boolean {
 	return validInputRegExp.test(input);


### PR DESCRIPTION
This PR adds a RegExp that is used to validate all user inputs. This will ensure that only numbers and decimals can be added to the text inputs on Firefox and Safari.

In addition, this PR adds a quick CSS fix that will render all of our icons correctly on Safari browser.