### PR TITLE
PE-144: Add aria-labels to text box input fields

### DIFF
--- a/src/components/TextBox.tsx
+++ b/src/components/TextBox.tsx
@@ -3,6 +3,7 @@ import { TextBoxContainer, TextBoxInput } from './TextBox.style';
 import CurrentUnit from './CurrentUnit';
 import type { UnitBoxes } from '../types';
 import { useStateValue } from '../state/state';
+import { getSpokenWord } from '../utils/get_spoken_word';
 
 interface TextBoxProps {
 	input?: number;
@@ -13,7 +14,12 @@ export default function TextBox({ input, field }: TextBoxProps): JSX.Element {
 	const [{ unitBoxes }] = useStateValue();
 	return (
 		<TextBoxContainer>
-			<TextBoxInput type="number" name="textbox" value={input} />
+			<TextBoxInput
+				type="number"
+				name="textbox"
+				value={input}
+				aria-label={`${getSpokenWord(unitBoxes[field].currUnit)} input field`}
+			/>
 			<CurrentUnit
 				onChange={(val) => console.log(val)}
 				units={unitBoxes[field].units}

--- a/src/utils/get_spoken_word.test.ts
+++ b/src/utils/get_spoken_word.test.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { getSpokenWord } from './get_spoken_word';
+
+describe('getSpokenWord function', () => {
+	it('correctly converts KB into kilobyte', () => {
+		expect(getSpokenWord('KB')).to.equal('kilobyte');
+	});
+
+	it('correctly converts MB into megabyte', () => {
+		expect(getSpokenWord('MB')).to.equal('megabyte');
+	});
+
+	it('correctly converts GB into gigabyte', () => {
+		expect(getSpokenWord('GB')).to.equal('gigabyte');
+	});
+
+	it('correctly converts AR into arweave token', () => {
+		expect(getSpokenWord('AR')).to.equal('arweave token');
+	});
+
+	it('correctly returns abbreviation if it does not exist on abbreviation record', () => {
+		expect(getSpokenWord('ROFL')).to.equal('ROFL');
+	});
+});

--- a/src/utils/get_spoken_word.ts
+++ b/src/utils/get_spoken_word.ts
@@ -1,0 +1,19 @@
+/** Returns spoken word if it exists on the abbreviation record, otherwise returns the abbreviation */
+export function getSpokenWord(abbreviation: string): string {
+	if (isAbbreviation(abbreviation)) {
+		return abbreviationRecord[abbreviation];
+	}
+
+	return abbreviation;
+}
+
+const abbreviationRecord = {
+	KB: 'kilobyte',
+	MB: 'megabyte',
+	GB: 'gigabyte',
+	AR: 'arweave token'
+};
+
+function isAbbreviation(key: string): key is keyof typeof abbreviationRecord {
+	return key in abbreviationRecord;
+}


### PR DESCRIPTION
This PR adds an abbreviation record for data/ar fields and a function that grabs the spoken word for a given abbreviation if it exists on that record. These are used inside the TextBox component to add aria-labels to the input elements.