### PR TITLE
PE-207: Fix text box input misalignment

### DIFF
--- a/src/components/TextBox.style.tsx
+++ b/src/components/TextBox.style.tsx
@@ -3,10 +3,10 @@ import styled from 'styled-components';
 export const TextBoxInput = styled.input`
 	width: 65%;
 	height: 50%;
-	padding: 0 1rem;
+	margin: 0 1rem;
 
 	@media (min-width: 800px) {
-		padding: 0 2rem;
+		margin: 0 2rem;
 	}
 `;
 


### PR DESCRIPTION
This PR fixes the text box input alignment issue. Using margin here instead of padding will correctly push the input container inside of the defined spacing.