### PR TITLE
fix(file comparison): Render with unique key value PE-208

### DIFF
--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -26,7 +26,7 @@ export default function Calculator(): JSX.Element {
 			<DottedDivider>
 				{fileComparisons.map((fileComparison) => (
 					<FileComparison
-						key={fileComparison[1][1]}
+						key={fileComparison[1][2]}
 						fileIcon={fileComparison[0]}
 						comparisonText={fileComparison[1]}
 					/>


### PR DESCRIPTION
This PR fixes the defect where extra file comparison components would be rendered when calculated values were identical.

 The FileComparison component was mistakenly being rendered with the calculated value as the key. Whenever two of these values are the same, React will lose track of the elements and unnecessarily render the extra components. 

To fix this issue, I used a key prop that remains unique. That value is on `fileComparison[1][2]` which is `"pictures" | "HD videos" | "songs” | ”office docs”`