### PR TITLE
chore(fiat units): Remove extra crypto tokens PE-211

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,22 @@ export const displayedByteUnitTypes: ByteUnitType[] = ['KB', 'MB', 'GB'];
 
 const currenciesFromOracle = currencyIDs.map((f) => f.toUpperCase());
 
-const currenciesNotToDisplay = ['XDR', 'XAG', 'XAU', 'BITS', 'SATS'];
+const currenciesNotToDisplay = [
+	'XDR',
+	'XAG',
+	'XAU',
+	'BITS',
+	'SATS',
+	'LTC',
+	'BCH',
+	'BNB',
+	'EOS',
+	'XRP',
+	'XLM',
+	'LINK',
+	'DOT',
+	'YFI'
+];
 
 /** Fiat unit types translated from the coingecko supported currencies */
 export const displayedFiatUnitTypes = currenciesFromOracle.filter((f) => !currenciesNotToDisplay.includes(f));


### PR DESCRIPTION
This PR removes the additional crypto tokens not included in PE-68's requirements from being displayed to the user