### PR TITLE
PE-205: Display error message when pricing oracles are unavailable

### DIFF
--- a/src/components/Calculator.style.tsx
+++ b/src/components/Calculator.style.tsx
@@ -4,8 +4,11 @@ export const CalculatorContainer = styled.section`
 	width: 100%;
 `;
 
-export const DottedDivider = styled.div`
-	background-image: linear-gradient(grey 17%, rgba(255, 255, 255, 0) 0%);
+export const DottedDivider = styled.div<{ dataToARError: boolean }>`
+	background-image: linear-gradient(
+		${(p) => (p.dataToARError ? `transparent` : `grey`)} 17%,
+		rgba(255, 255, 255, 0) 0%
+	);
 	background-position: left;
 	background-size: 2px 10px;
 	background-repeat: repeat-y;
@@ -14,6 +17,8 @@ export const DottedDivider = styled.div`
 	display: flex;
 	justify-content: space-evenly;
 	flex-direction: column;
+
+	${(p) => p.dataToARError && { backgroundImage: 'linear-gradient(transparent 17%, rgba(255, 255, 255, 0) 0%)' }}
 
 	@media (min-width: 800px) {
 		margin-left: 4rem;

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -12,7 +12,7 @@ export interface FileComparison {
 }
 
 export default function Calculator(): JSX.Element {
-	const [{ unitBoxes }] = useStateValue();
+	const [{ unitBoxes, oracleErrors }] = useStateValue();
 
 	useCalculation();
 
@@ -22,12 +22,13 @@ export default function Calculator(): JSX.Element {
 		<CalculatorContainer>
 			<TextBox field={'fiat'}></TextBox>
 			<TextBox field={'bytes'}></TextBox>
-			<DottedDivider>
+			<DottedDivider dataToARError={oracleErrors.dataToAR}>
 				{fileComparisons.map((fileComparison) => (
 					<FileComparison
 						key={fileComparison[1][2]}
 						fileIcon={fileComparison[0]}
 						comparisonText={fileComparison[1]}
+						dataToARError={oracleErrors.dataToAR}
 					/>
 				))}
 			</DottedDivider>

--- a/src/components/FileComparison.tsx
+++ b/src/components/FileComparison.tsx
@@ -4,9 +4,10 @@ import { FileComparisonTypeIconContainer, FileComparisonContainer } from './File
 interface FileComparisonProps {
 	fileIcon: JSX.Element;
 	comparisonText: string[];
+	dataToARError: boolean;
 }
 
-export default function FileComparison({ fileIcon, comparisonText }: FileComparisonProps): JSX.Element {
+export default function FileComparison({ fileIcon, comparisonText, dataToARError }: FileComparisonProps): JSX.Element {
 	const wavehausBookComparisonText = comparisonText[0];
 	const comparisonValue = comparisonText[1];
 	const wavehausBoldComparisonText = comparisonText[2];
@@ -15,11 +16,17 @@ export default function FileComparison({ fileIcon, comparisonText }: FileCompari
 		<FileComparisonContainer>
 			<FileComparisonTypeIconContainer>{fileIcon}</FileComparisonTypeIconContainer>
 			<p>
-				{wavehausBookComparisonText}{' '}
-				<strong>
-					<span>{comparisonValue}</span>
-					{wavehausBoldComparisonText}
-				</strong>
+				{dataToARError ? (
+					<strong>. . .</strong>
+				) : (
+					<>
+						{wavehausBookComparisonText}
+						<strong>
+							<span>{comparisonValue}</span>
+							{wavehausBoldComparisonText}
+						</strong>
+					</>
+				)}
 			</p>
 		</FileComparisonContainer>
 	);

--- a/src/components/TextBox.style.tsx
+++ b/src/components/TextBox.style.tsx
@@ -11,7 +11,7 @@ export const TextBoxInput = styled.input`
 	}
 `;
 
-export const TextBoxContainer = styled.div`
+export const TextBoxContainer = styled.div<{ hasError: boolean }>`
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
@@ -21,9 +21,11 @@ export const TextBoxContainer = styled.div`
 	box-shadow: 0 0 10px 5px rgba(213, 213, 213, 0.5);
 	font-family: 'Wavehaus-Bold';
 
-	border: 1px;
-	border-color: transparent;
+	border-width: ${(p) => (p.hasError ? `3px` : `1px`)};
+	border-color: ${(p) => (p.hasError ? `red` : `transparent`)};
 	border-style: solid;
+
+	${(p) => p.hasError && `border-color: red`}
 
 	:focus-within {
 		border-color: #4c4c4c;
@@ -44,5 +46,37 @@ export const TextBoxContainer = styled.div`
 
 	@media (min-width: 1200px) {
 		height: 75px;
+	}
+`;
+
+export const ErrorMessage = styled.span`
+	color: red;
+	position: absolute;
+	font-family: 'Wavehaus-Bold';
+
+	font-size: 12px;
+	padding-top: 6.5rem;
+
+	@media (min-width: 324px) {
+		padding-top: 5.5rem;
+	}
+
+	@media (min-width: 480px) {
+		font-size: 14px;
+		padding-left: 3rem;
+	}
+
+	@media (min-width: 640px) {
+		padding-left: 6rem;
+	}
+
+	@media (min-width: 800px) {
+		padding-left: 1rem;
+		padding-top: 6.5rem;
+	}
+
+	@media (min-width: 1200px) {
+		padding-left: 5rem;
+		padding-top: 7.5rem;
 	}
 `;

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -3,7 +3,11 @@ import type { State } from './state';
 
 export type Action =
 	| { type: 'setArDriveCommunityTip'; payload: ArDriveCommunityTip }
-	| { type: 'setUnitBoxes'; payload: UnitBoxes };
+	| { type: 'setUnitBoxes'; payload: UnitBoxes }
+	| { type: 'setFiatToARError' }
+	| { type: 'clearFiatToARError' }
+	| { type: 'setDataToARError' }
+	| { type: 'clearDataToARError' };
 
 export const reducer = (state: State, action: Action): State => {
 	switch (action.type) {
@@ -21,6 +25,42 @@ export const reducer = (state: State, action: Action): State => {
 			return {
 				...state,
 				unitBoxes: action.payload
+			};
+
+		case 'setFiatToARError':
+			return {
+				...state,
+				oracleErrors: {
+					...state.oracleErrors,
+					fiatToAR: true
+				}
+			};
+
+		case 'clearFiatToARError':
+			return {
+				...state,
+				oracleErrors: {
+					...state.oracleErrors,
+					fiatToAR: false
+				}
+			};
+
+		case 'setDataToARError':
+			return {
+				...state,
+				oracleErrors: {
+					...state.oracleErrors,
+					dataToAR: true
+				}
+			};
+
+		case 'clearDataToARError':
+			return {
+				...state,
+				oracleErrors: {
+					...state.oracleErrors,
+					dataToAR: false
+				}
 			};
 
 		default:

--- a/src/state/state.tsx
+++ b/src/state/state.tsx
@@ -1,5 +1,12 @@
 import React, { createContext, Dispatch, useContext, useReducer } from 'react';
-import { ArDriveCommunityTip, displayedByteUnitTypes, displayedFiatUnitTypes, OracleErrors, UnitBoxes } from '../types';
+import {
+	ArDriveCommunityTip,
+	displayedByteUnitTypes,
+	displayedFiatUnitTypes,
+	doNotRenderValue,
+	OracleErrors,
+	UnitBoxes
+} from '../types';
 import type { Action } from './reducer';
 
 export type State = {
@@ -29,9 +36,8 @@ const initialState: State = {
 	/** Unit boxes display only 1 GiB by default, other values to be filled in on first calculation */
 	unitBoxes: {
 		bytes: { value: 1, currUnit: 'GB', units: displayedByteUnitTypes },
-		// Default -1 values here are to conditionally render input fields when data arrives
-		fiat: { value: -1, currUnit: 'USD', units: displayedFiatUnitTypes },
-		ar: { value: -1, currUnit: 'AR' }
+		fiat: { value: doNotRenderValue, currUnit: 'USD', units: displayedFiatUnitTypes },
+		ar: { value: doNotRenderValue, currUnit: 'AR' }
 	},
 
 	oracleErrors: {

--- a/src/state/state.tsx
+++ b/src/state/state.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, Dispatch, useContext, useReducer } from 'react';
-import { ArDriveCommunityTip, displayedByteUnitTypes, displayedFiatUnitTypes, UnitBoxes } from '../types';
+import { ArDriveCommunityTip, displayedByteUnitTypes, displayedFiatUnitTypes, OracleErrors, UnitBoxes } from '../types';
 import type { Action } from './reducer';
 
 export type State = {
@@ -11,6 +11,9 @@ export type State = {
 
 	/** Current values and units for each field: 'bytes' | 'fiat' | 'ar' */
 	unitBoxes: UnitBoxes;
+
+	/** State for displaying errors from fiat and data oracles */
+	oracleErrors: OracleErrors;
 };
 
 /** ArDrive Price Calculator's initial state */
@@ -29,6 +32,11 @@ const initialState: State = {
 		// Default -1 values here are to conditionally render input fields when data arrives
 		fiat: { value: -1, currUnit: 'USD', units: displayedFiatUnitTypes },
 		ar: { value: -1, currUnit: 'AR' }
+	},
+
+	oracleErrors: {
+		fiatToAR: false,
+		dataToAR: false
 	}
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,3 +65,6 @@ export interface OracleErrors {
 	fiatToAR: boolean;
 	dataToAR: boolean;
 }
+
+/** Unit boxes will not render values when set to -1 */
+export const doNotRenderValue = -1;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,3 +60,8 @@ export interface UnitBoxes {
 	fiat: FiatUnitBox;
 	ar: ArUnitBox;
 }
+
+export interface OracleErrors {
+	fiatToAR: boolean;
+	dataToAR: boolean;
+}

--- a/src/utils/ar_data_price_regression_estimator.ts
+++ b/src/utils/ar_data_price_regression_estimator.ts
@@ -150,6 +150,14 @@ export class ARDataPriceRegressionEstimator implements ARDataPriceEstimator {
 		arPrice: number,
 		{ minWinstonFee, tipPercentage }: ArDriveCommunityTip
 	): Promise<number> {
+		// Lazily generate the price predictor
+		if (!this.predictor) {
+			await this.refreshPriceData();
+			if (!this.predictor) {
+				throw Error('Failed to generate pricing model!');
+			}
+		}
+
 		const winstonPrice = arPrice / arPerWinston;
 
 		const communityWinstonFee = Math.max(winstonPrice - winstonPrice / (1 + tipPercentage), minWinstonFee);

--- a/src/utils/calculate_unit_boxes.test.ts
+++ b/src/utils/calculate_unit_boxes.test.ts
@@ -42,21 +42,21 @@ describe('UnitBoxCalculator class', () => {
 
 	it('calculateUnitBoxValues function returns the correct UnitBoxValues for 0 bytes', async () => {
 		const actual = await unitBoxCalculator.calculateUnitBoxValues(0, 'bytes', 'usd', 'KB', arDriveCommunityTip);
-		expect(actual).to.deep.equal({ bytes: 0, fiat: 0, ar: 0 });
+		expect(actual[0]).to.deep.equal({ bytes: 0, fiat: 0, ar: 0 });
 	});
 
 	it('calculateUnitBoxValues function returns the correct unitBoxes when using the bytes unit to calculate', async () => {
 		const actual = await unitBoxCalculator.calculateUnitBoxValues(1, 'bytes', 'usd', 'KB', arDriveCommunityTip);
-		expect(actual).to.deep.equal(expectedResult);
+		expect(actual[0]).to.deep.equal(expectedResult);
 	});
 
 	it('calculateUnitBoxValues function returns the correct unitBoxes when using the fiat unit to calculate', async () => {
 		const actual = await unitBoxCalculator.calculateUnitBoxValues(10, 'fiat', 'usd', 'KB', arDriveCommunityTip);
-		expect(actual).to.deep.equal(expectedResult);
+		expect(actual[0]).to.deep.equal(expectedResult);
 	});
 
 	it('calculateUnitBoxValues function returns the correct unitBoxes when using the ar unit to calculate', async () => {
 		const actual = await unitBoxCalculator.calculateUnitBoxValues(1, 'ar', 'usd', 'KB', arDriveCommunityTip);
-		expect(actual).to.deep.equal(expectedResult);
+		expect(actual[0]).to.deep.equal(expectedResult);
 	});
 });

--- a/src/utils/calculate_unit_boxes.test.ts
+++ b/src/utils/calculate_unit_boxes.test.ts
@@ -43,22 +43,22 @@ describe('UnitBoxCalculator class', () => {
 	describe('calculateUnitBoxValues function ', () => {
 		it('returns the correct UnitBoxValues for 0 bytes', async () => {
 			const actual = await unitBoxCalculator.calculateUnitBoxValues(0, 'bytes', 'usd', 'KB', arDriveCommunityTip);
-			expect(actual[0]).to.deep.equal({ bytes: 0, fiat: 0, ar: 0 });
+			expect(actual.unitBoxValues).to.deep.equal({ bytes: 0, fiat: 0, ar: 0 });
 		});
 
 		it('returns the correct unitBoxes when using the bytes unit to calculate', async () => {
 			const actual = await unitBoxCalculator.calculateUnitBoxValues(1, 'bytes', 'usd', 'KB', arDriveCommunityTip);
-			expect(actual[0]).to.deep.equal(expectedResult);
+			expect(actual.unitBoxValues).to.deep.equal(expectedResult);
 		});
 
 		it('returns the correct unitBoxes when using the fiat unit to calculate', async () => {
 			const actual = await unitBoxCalculator.calculateUnitBoxValues(10, 'fiat', 'usd', 'KB', arDriveCommunityTip);
-			expect(actual[0]).to.deep.equal(expectedResult);
+			expect(actual.unitBoxValues).to.deep.equal(expectedResult);
 		});
 
 		it('returns the correct unitBoxes when using the ar unit to calculate', async () => {
 			const actual = await unitBoxCalculator.calculateUnitBoxValues(1, 'ar', 'usd', 'KB', arDriveCommunityTip);
-			expect(actual[0]).to.deep.equal(expectedResult);
+			expect(actual.unitBoxValues).to.deep.equal(expectedResult);
 		});
 
 		it('returns an arToData error when using the `getARPriceForByteCount` method and the ARDataPriceEstimator fails to fetch AR<>Data pricing estimates', async () => {
@@ -67,7 +67,7 @@ describe('UnitBoxCalculator class', () => {
 
 			const actual = await unitBoxCalculator.calculateUnitBoxValues(1, 'bytes', 'usd', 'KB', arDriveCommunityTip);
 
-			expect(actual[1].dataToAR).to.be.true;
+			expect(actual.oracleErrors.dataToAR).to.be.true;
 		});
 
 		it('returns an arToData error when using the `getByteCountForAR` method and the ARDataPriceEstimator fails to fetch AR<>Data pricing estimates', async () => {
@@ -76,7 +76,7 @@ describe('UnitBoxCalculator class', () => {
 
 			const actual = await unitBoxCalculator.calculateUnitBoxValues(1, 'ar', 'usd', 'KB', arDriveCommunityTip);
 
-			expect(actual[1].dataToAR).to.be.true;
+			expect(actual.oracleErrors.dataToAR).to.be.true;
 		});
 
 		it('returns a fiatToData error when the `getPriceForFiatTokenPair` method fails to retrieve the fiatPerAR price from the CachingTokenToFiatOracle', async () => {
@@ -87,7 +87,7 @@ describe('UnitBoxCalculator class', () => {
 
 			const actual = await unitBoxCalculator.calculateUnitBoxValues(1, 'bytes', 'usd', 'KB', arDriveCommunityTip);
 
-			expect(actual[1].fiatToAR).to.be.true;
+			expect(actual.oracleErrors.fiatToAR).to.be.true;
 		});
 	});
 });

--- a/src/utils/calculate_unit_boxes.test.ts
+++ b/src/utils/calculate_unit_boxes.test.ts
@@ -40,23 +40,54 @@ describe('UnitBoxCalculator class', () => {
 		expect(unitBoxCalculator.fiatOracle).to.deep.equal(cachingTokenToOracle);
 	});
 
-	it('calculateUnitBoxValues function returns the correct UnitBoxValues for 0 bytes', async () => {
-		const actual = await unitBoxCalculator.calculateUnitBoxValues(0, 'bytes', 'usd', 'KB', arDriveCommunityTip);
-		expect(actual[0]).to.deep.equal({ bytes: 0, fiat: 0, ar: 0 });
-	});
+	describe('calculateUnitBoxValues function ', () => {
+		it('returns the correct UnitBoxValues for 0 bytes', async () => {
+			const actual = await unitBoxCalculator.calculateUnitBoxValues(0, 'bytes', 'usd', 'KB', arDriveCommunityTip);
+			expect(actual[0]).to.deep.equal({ bytes: 0, fiat: 0, ar: 0 });
+		});
 
-	it('calculateUnitBoxValues function returns the correct unitBoxes when using the bytes unit to calculate', async () => {
-		const actual = await unitBoxCalculator.calculateUnitBoxValues(1, 'bytes', 'usd', 'KB', arDriveCommunityTip);
-		expect(actual[0]).to.deep.equal(expectedResult);
-	});
+		it('returns the correct unitBoxes when using the bytes unit to calculate', async () => {
+			const actual = await unitBoxCalculator.calculateUnitBoxValues(1, 'bytes', 'usd', 'KB', arDriveCommunityTip);
+			expect(actual[0]).to.deep.equal(expectedResult);
+		});
 
-	it('calculateUnitBoxValues function returns the correct unitBoxes when using the fiat unit to calculate', async () => {
-		const actual = await unitBoxCalculator.calculateUnitBoxValues(10, 'fiat', 'usd', 'KB', arDriveCommunityTip);
-		expect(actual[0]).to.deep.equal(expectedResult);
-	});
+		it('returns the correct unitBoxes when using the fiat unit to calculate', async () => {
+			const actual = await unitBoxCalculator.calculateUnitBoxValues(10, 'fiat', 'usd', 'KB', arDriveCommunityTip);
+			expect(actual[0]).to.deep.equal(expectedResult);
+		});
 
-	it('calculateUnitBoxValues function returns the correct unitBoxes when using the ar unit to calculate', async () => {
-		const actual = await unitBoxCalculator.calculateUnitBoxValues(1, 'ar', 'usd', 'KB', arDriveCommunityTip);
-		expect(actual[0]).to.deep.equal(expectedResult);
+		it('returns the correct unitBoxes when using the ar unit to calculate', async () => {
+			const actual = await unitBoxCalculator.calculateUnitBoxValues(1, 'ar', 'usd', 'KB', arDriveCommunityTip);
+			expect(actual[0]).to.deep.equal(expectedResult);
+		});
+
+		it('returns an arToData error when using the `getARPriceForByteCount` method and the ARDataPriceEstimator fails to fetch AR<>Data pricing estimates', async () => {
+			stubbedPriceEstimator.getARPriceForByteCount.throws();
+			unitBoxCalculator = new UnitBoxCalculator(stubbedPriceEstimator, cachingTokenToOracle);
+
+			const actual = await unitBoxCalculator.calculateUnitBoxValues(1, 'bytes', 'usd', 'KB', arDriveCommunityTip);
+
+			expect(actual[1].dataToAR).to.be.true;
+		});
+
+		it('returns an arToData error when using the `getByteCountForAR` method and the ARDataPriceEstimator fails to fetch AR<>Data pricing estimates', async () => {
+			stubbedPriceEstimator.getByteCountForAR.throws();
+			unitBoxCalculator = new UnitBoxCalculator(stubbedPriceEstimator, cachingTokenToOracle);
+
+			const actual = await unitBoxCalculator.calculateUnitBoxValues(1, 'ar', 'usd', 'KB', arDriveCommunityTip);
+
+			expect(actual[1].dataToAR).to.be.true;
+		});
+
+		it('returns a fiatToData error when the `getPriceForFiatTokenPair` method fails to retrieve the fiatPerAR price from the CachingTokenToFiatOracle', async () => {
+			stubbedCoinGeckoOracle.getFiatRatesForToken.throws();
+			cachingTokenToOracle = new CachingTokenToFiatOracle('arweave', currencyIDs, 2000, stubbedCoinGeckoOracle);
+
+			unitBoxCalculator = new UnitBoxCalculator(stubbedPriceEstimator, cachingTokenToOracle);
+
+			const actual = await unitBoxCalculator.calculateUnitBoxValues(1, 'bytes', 'usd', 'KB', arDriveCommunityTip);
+
+			expect(actual[1].fiatToAR).to.be.true;
+		});
 	});
 });

--- a/src/utils/calculate_unit_boxes.ts
+++ b/src/utils/calculate_unit_boxes.ts
@@ -44,7 +44,7 @@ export class UnitBoxCalculator {
 		fiatUnit: FiatID,
 		byteUnit: ByteUnitType,
 		arDriveCommunityTip: ArDriveCommunityTip
-	): Promise<[UnitBoxValues, OracleErrors]> {
+	): Promise<{ unitBoxValues: UnitBoxValues; oracleErrors: OracleErrors }> {
 		let newARValue: number;
 		let userDefinedByteValue: number | undefined = undefined;
 		let oracleErrors: OracleErrors = { fiatToAR: false, dataToAR: false };
@@ -109,6 +109,6 @@ export class UnitBoxCalculator {
 		const newByteValue = !oracleErrors.dataToAR ? byteCount : -1;
 		const newArValue = newARValue;
 
-		return [{ bytes: newByteValue, fiat: newFiatValue, ar: newArValue }, oracleErrors];
+		return { unitBoxValues: { bytes: newByteValue, fiat: newFiatValue, ar: newArValue }, oracleErrors };
 	}
 }

--- a/src/utils/calculate_unit_boxes.ts
+++ b/src/utils/calculate_unit_boxes.ts
@@ -9,9 +9,6 @@ import { currencyIDs, FiatID } from './fiat_oracle_types';
 /**
  * A utility class responsible for calculating the new unit boxes to
  * display to the user based on the changes to the global state
- *
- * @remarks Will construct a new ARDataPriceEstimator upon initial
- * creation, which fires off 3 network calls for AR<>Data models
  */
 export class UnitBoxCalculator {
 	constructor(
@@ -36,7 +33,10 @@ export class UnitBoxCalculator {
 	 * @param byteUnit current byte unit type from global state
 	 * @param arDriveCommunityTip current ArDrive community fee from global state
 	 *
-	 * @returns newly calculated unit box values
+	 * @remarks Will fire off three fetch calls for AR<>Data and one
+	 *          fetch call for Fiat<>AR on the first call of this function
+	 *
+	 * @returns newly calculated unit box values and any oracleErrors that occur
 	 */
 	async calculateUnitBoxValues(
 		value: number,

--- a/src/utils/calculate_unit_boxes.ts
+++ b/src/utils/calculate_unit_boxes.ts
@@ -1,5 +1,5 @@
 import type { UnitBoxValues } from '../hooks/useCalculation';
-import type { ArDriveCommunityTip, ByteUnitType, OracleErrors, UnitBoxes } from '../types';
+import { ArDriveCommunityTip, ByteUnitType, doNotRenderValue, OracleErrors, UnitBoxes } from '../types';
 import { ARDataPriceRegressionEstimator } from './ar_data_price_regression_estimator';
 import convertUnit from './convert_unit';
 import type { ARDataPriceEstimator } from './ar_data_price_estimator';
@@ -99,14 +99,12 @@ export class UnitBoxCalculator {
 				byteCount = convertUnit(Math.round(rawByteCount), 'B', byteUnit);
 			} catch {
 				oracleErrors = { ...oracleErrors, dataToAR: true };
-				byteCount = -1;
+				byteCount = doNotRenderValue;
 			}
 		}
 
-		// If `fiatPerAR` remains initially undefined (is fetching) or there are,
-		// oracle errors set new values to -1 for conditionally hiding the unit boxes
-		const newFiatValue = !oracleErrors.fiatToAR && fiatPerAR ? newARValue * fiatPerAR : -1;
-		const newByteValue = !oracleErrors.dataToAR ? byteCount : -1;
+		const newFiatValue = !oracleErrors.fiatToAR && fiatPerAR ? newARValue * fiatPerAR : doNotRenderValue;
+		const newByteValue = !oracleErrors.dataToAR ? byteCount : doNotRenderValue;
 		const newArValue = newARValue;
 
 		return { unitBoxValues: { bytes: newByteValue, fiat: newFiatValue, ar: newArValue }, oracleErrors };

--- a/src/utils/calculate_unit_boxes.ts
+++ b/src/utils/calculate_unit_boxes.ts
@@ -54,9 +54,8 @@ export class UnitBoxCalculator {
 		try {
 			fiatPerAR = (await this.fiatCachingOracle.getPriceForFiatTokenPair({ token: 'arweave', fiat: fiatUnit }))
 				.fiatPerTokenRate;
-		} catch (error) {
+		} catch {
 			oracleErrors = { ...oracleErrors, fiatToAR: true };
-			console.error('Fiat prices could not be fetched from the CoinGecko API..', error);
 		}
 
 		switch (unit) {
@@ -71,10 +70,9 @@ export class UnitBoxCalculator {
 							Math.round(convertUnit(value, byteUnit, 'B')),
 							arDriveCommunityTip
 						);
-					} catch (error) {
+					} catch {
 						newARValue = 1;
 						oracleErrors = { ...oracleErrors, dataToAR: true };
-						console.error('Data prices could not be fetched from the Arweave gateway..', error);
 					}
 				}
 
@@ -99,10 +97,9 @@ export class UnitBoxCalculator {
 			try {
 				const rawByteCount = await this.arDataPriceEstimator.getByteCountForAR(newARValue, arDriveCommunityTip);
 				byteCount = convertUnit(Math.round(rawByteCount), 'B', byteUnit);
-			} catch (error) {
+			} catch {
 				oracleErrors = { ...oracleErrors, dataToAR: true };
 				byteCount = -1;
-				console.error('Data prices could not be fetched from the Arweave gateway..', error);
 			}
 		}
 


### PR DESCRIPTION
This PR adds error messages when each oracle fails to fetch a pricing estimate. This errors are caught in the `CalculateUnitBoxes` class and are dispatched to the `oracleErrors` state in the `useCalculation` hook. The components that need to display these errors conditionally render dependent on the status of the `oracleErrors` state.

Catching these errors properly allows for 2/3 of the boxes to be used in the case that only one oracle fails to fetch, irregardless of which oracle failed. For example, a user can now use the AR<>Data fields if CoinGecko fails to fetch. And a user can now use Fiat<>AR fields if the Arweave gateway fails to fetch.