### PR TITLE
PE-216: Add aria labels to dropdown items

### DIFF
--- a/src/components/CurrentUnit.tsx
+++ b/src/components/CurrentUnit.tsx
@@ -11,6 +11,7 @@ import useOnOutsideClick from '../hooks/useOnOutsideClick';
 import UpArrowIcon from './icons/UpArrowIcon';
 import { useStateValue } from '../state/state';
 import type { ByteUnitType } from '../types';
+import { getSpokenWord } from '../utils/get_spoken_word';
 
 interface CurrentUnitProps {
 	units?: string[];
@@ -76,7 +77,10 @@ function UnitDropDown({ units, closeDropDown }: UnitDropDownProps): JSX.Element 
 		<UnitsDropDownContainer>
 			{units.map((val) => (
 				<li key={val}>
-					<DropDownListItem aria-label="Set current unit" onClick={() => onUnitClick(val)}>
+					<DropDownListItem
+						aria-label={`Set current unit to ${getSpokenWord(val)}`}
+						onClick={() => onUnitClick(val)}
+					>
 						{val}
 					</DropDownListItem>
 				</li>

--- a/src/components/CurrentUnit.tsx
+++ b/src/components/CurrentUnit.tsx
@@ -77,10 +77,7 @@ function UnitDropDown({ units, closeDropDown }: UnitDropDownProps): JSX.Element 
 		<UnitsDropDownContainer>
 			{units.map((val) => (
 				<li key={val}>
-					<DropDownListItem
-						aria-label={`Set current unit to ${getSpokenWord(val)}`}
-						onClick={() => onUnitClick(val)}
-					>
+					<DropDownListItem aria-label={`Set unit to ${getSpokenWord(val)}`} onClick={() => onUnitClick(val)}>
 						{val}
 					</DropDownListItem>
 				</li>

--- a/src/utils/get_spoken_word.ts
+++ b/src/utils/get_spoken_word.ts
@@ -13,7 +13,7 @@ const abbreviationRecord = {
 	GB: 'gigabyte',
 	ETH: 'ethereum',
 	BTC: 'bitcoin',
-	USD: 'us dollar',
+	USD: 'u s dollar',
 	JPY: 'japanese yen',
 	EUR: 'euro'
 };

--- a/src/utils/get_spoken_word.ts
+++ b/src/utils/get_spoken_word.ts
@@ -10,7 +10,12 @@ export function getSpokenWord(abbreviation: string): string {
 const abbreviationRecord = {
 	KB: 'kilobyte',
 	MB: 'megabyte',
-	GB: 'gigabyte'
+	GB: 'gigabyte',
+	ETH: 'ethereum',
+	BTC: 'bitcoin',
+	USD: 'us dollar',
+	JPY: 'japanese yen',
+	EUR: 'euro'
 };
 
 function isAbbreviation(key: string): key is keyof typeof abbreviationRecord {


### PR DESCRIPTION
This PR adjusts the aria labels on the dropdown items to use the unit abbreviation or spoken word in the screen reader output.