### PR TITLE
PE-217: Improve FAQ screen readability

### DIFF
--- a/src/components/Expandable.tsx
+++ b/src/components/Expandable.tsx
@@ -3,26 +3,22 @@ import { ExpandableContainer, ExpandableTitle, ExpandableTrailingIcon } from './
 import UpArrowIcon from './icons/UpArrowIcon';
 
 interface ExpandableProps {
-	title: string;
-	description: React.ReactNode;
+	question: string;
+	answer: React.ReactNode;
 	expanded: boolean;
 	setExpanded: () => void;
 }
 
-export default function Expandable({ title, description, expanded, setExpanded }: ExpandableProps): JSX.Element {
+export default function Expandable({ question, answer, expanded, setExpanded }: ExpandableProps): JSX.Element {
 	return (
 		<ExpandableContainer>
-			<ExpandableTitle
-				aria-label={expanded ? 'Hide answer' : 'Expand answer'}
-				onClick={() => setExpanded()}
-				expanded={expanded}
-			>
-				{title}
+			<ExpandableTitle aria-label={question} onClick={() => setExpanded()} expanded={expanded}>
+				<h3>{question}</h3>
 				<ExpandableTrailingIcon expanded={expanded}>
 					<UpArrowIcon />
 				</ExpandableTrailingIcon>
 			</ExpandableTitle>{' '}
-			{expanded && <>{description}</>}
+			{expanded && <>{answer}</>}
 		</ExpandableContainer>
 	);
 }

--- a/src/components/Faq.tsx
+++ b/src/components/Faq.tsx
@@ -8,7 +8,7 @@ export default function Faq(): JSX.Element {
 
 	return (
 		<FaqContainer>
-			<h2>FAQs</h2>
+			<h2 aria-label="Frequently asked questions">FAQs</h2>
 			{faqQuestionsAnswers.map((qa, index) => (
 				<Expandable
 					key={qa.question}

--- a/src/components/Faq.tsx
+++ b/src/components/Faq.tsx
@@ -12,8 +12,8 @@ export default function Faq(): JSX.Element {
 			{faqQuestionsAnswers.map((qa, index) => (
 				<Expandable
 					key={qa.question}
-					title={qa.question}
-					description={qa.answer}
+					question={qa.question}
+					answer={qa.answer}
 					expanded={index === expanded}
 					setExpanded={() => (index === expanded ? setExpanded(undefined) : setExpanded(index))}
 				></Expandable>

--- a/src/index.css
+++ b/src/index.css
@@ -16,8 +16,11 @@ ul {
     list-style: none;
 }
 
-h2 {
+h2,
+h3 {
     font-size: inherit;
+    font-family: inherit;
+    font-weight: inherit;
     margin: 0;
 }
 


### PR DESCRIPTION
This PR improves the accessibility for screen readers in the FAQ component. 

I adjusted the HTML structure of the Expandable component to be more semantic, with the answer being rendered as an `<h3>`. 

I also updated the aria label of the button to simply read out the entire answer, since the question is directly relevant to the action that it opens. The latter change allows a user with a screen reader to hear the answer read out directly.

In addition, the "FAQs" text itself now has an aria-label that reads "Frequently asked questions"